### PR TITLE
fix(vuln): update Go 1.26.1 → 1.26.2 to fix stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-storage-azcopy/v10
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go/storage v1.45.0


### PR DESCRIPTION
## Summary

- Update `go 1.26.1` → `go 1.26.2` in `go.mod`

## Fixed CVEs

| Severity | CVSS | CVE | Package |
|----------|------|-----|---------|
| HIGH | 8.8 | CVE-2026-33810 | stdlib |
| HIGH | 7.8 | CVE-2026-32282 | stdlib |
| HIGH | 7.5 | CVE-2026-32280 | stdlib |
| MEDIUM | 5.9 | CVE-2026-32281 | stdlib |
| MEDIUM | 5.4 | CVE-2026-32289 | stdlib |
| MEDIUM | 4.3 | CVE-2026-32288 | stdlib |
| UNKNOWN | - | CVE-2026-32283 | stdlib |

## Test plan

- [ ] CI builds pass
- [ ] New release tagged and binaries confirm `go version` = 1.26.2