### PR TITLE
fix(vuln): CVE remediation 2026-05-09

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-storage-azcopy/v10
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/storage v1.45.0


### PR DESCRIPTION
Automated CVE fix: updated Go 1.26.2 → 1.26.3, fixing stdlib vulnerabilities (html/template XSS, net/http HTTP/2, net NUL byte panic).