### PR TITLE
fix(vuln): bump go 1.26.4 to patch stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-storage-azcopy/v10
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/storage v1.45.0


### PR DESCRIPTION
## Summary
- Bump `go` directive 1.26.3 → 1.26.4

## CVEs (stdlib)
- CVE-2026-42504 (7.5), CVE-2026-27145 (6.5), CVE-2026-42507 (5.3)

Needed by gitlab-chart alauda-18.5.4 vuln scan (azcopy binary embeds stdlib in gitlab-toolbox image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)